### PR TITLE
DVDArt Release

### DIFF
--- a/MPEI/DVDArt_Plugin.xmp2
+++ b/MPEI/DVDArt_Plugin.xmp2
@@ -326,10 +326,12 @@ Click Next to continue or Cancel to exit Setup.</Value>
 * Fixed static version value
 * Bump ImageMagick version to 7.0.8.11
 * Fix SQLite.Interop location
+* Resolved bug where the default Any value as language option skips downloading images
+* Changed DefaultConnectionLimit to 200 because images were not downloading.
 </VersionDescription>
     <DevelopmentStatus>Stable</DevelopmentStatus>
     <OnlineLocation>https://github.com/Mediaportal-Plugin-Team/DVDArt/releases/download/v[Version]/[Name]-v[Version].mpe1</OnlineLocation>
-    <ReleaseDate>2024-05-21T21:21:21</ReleaseDate>
+    <ReleaseDate>2024-05-23T15:15:15</ReleaseDate>
     <Tags>dvdart, cover art, clear art, clear logo, scraper, movingpictures, tvseries, music, actors, writers, directors, myfilms</Tags>
     <PlatformCompatibility>AnyCPU</PlatformCompatibility>
     <Location>[Name]-v[Version].mpe1</Location>


### PR DESCRIPTION
* Resolved bug where the default Any value as language option skips downloading images
* Changed DefaultConnectionLimit to 200 because images were not downloading.